### PR TITLE
Add more specific exceptions Issue #1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.marcofaccani'
-version = '1.0.0-SNAPSHOT'
+version = '1.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'

--- a/src/main/java/com/marcofaccani/awss3/exceptions/S3BucketCreationException.java
+++ b/src/main/java/com/marcofaccani/awss3/exceptions/S3BucketCreationException.java
@@ -1,0 +1,9 @@
+package com.marcofaccani.awss3.exceptions;
+
+public class S3BucketCreationException extends RuntimeException {
+
+  public S3BucketCreationException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/marcofaccani/awss3/exceptions/S3GetObjectException.java
+++ b/src/main/java/com/marcofaccani/awss3/exceptions/S3GetObjectException.java
@@ -1,0 +1,9 @@
+package com.marcofaccani.awss3.exceptions;
+
+public class S3GetObjectException extends RuntimeException {
+
+  public S3GetObjectException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/marcofaccani/awss3/exceptions/S3ListObjectsException.java
+++ b/src/main/java/com/marcofaccani/awss3/exceptions/S3ListObjectsException.java
@@ -1,0 +1,9 @@
+package com.marcofaccani.awss3.exceptions;
+
+public class S3ListObjectsException extends RuntimeException {
+
+  public S3ListObjectsException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/marcofaccani/awss3/exceptions/S3ObjectDeleteException.java
+++ b/src/main/java/com/marcofaccani/awss3/exceptions/S3ObjectDeleteException.java
@@ -1,0 +1,9 @@
+package com.marcofaccani.awss3.exceptions;
+
+public class S3ObjectDeleteException extends RuntimeException {
+
+  public S3ObjectDeleteException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/marcofaccani/awss3/exceptions/S3PresignedUrlException.java
+++ b/src/main/java/com/marcofaccani/awss3/exceptions/S3PresignedUrlException.java
@@ -1,0 +1,9 @@
+package com.marcofaccani.awss3.exceptions;
+
+public class S3PresignedUrlException extends RuntimeException {
+
+  public S3PresignedUrlException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/marcofaccani/awss3/exceptions/S3PutObjectException.java
+++ b/src/main/java/com/marcofaccani/awss3/exceptions/S3PutObjectException.java
@@ -1,0 +1,9 @@
+package com.marcofaccani.awss3.exceptions;
+
+public class S3PutObjectException extends RuntimeException {
+
+  public S3PutObjectException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/marcofaccani/awss3/exceptions/S3UnauthorizedException.java
+++ b/src/main/java/com/marcofaccani/awss3/exceptions/S3UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.marcofaccani.awss3.exceptions;
+
+public class S3UnauthorizedException extends RuntimeException {
+
+  public S3UnauthorizedException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/marcofaccani/awss3/service/BucketServiceImpl.java
+++ b/src/main/java/com/marcofaccani/awss3/service/BucketServiceImpl.java
@@ -1,5 +1,7 @@
 package com.marcofaccani.awss3.service;
 
+import com.marcofaccani.awss3.exceptions.S3BucketCreationException;
+import com.marcofaccani.awss3.exceptions.S3UnauthorizedException;
 import com.marcofaccani.awss3.service.interfaces.BucketService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -37,7 +39,7 @@ public class BucketServiceImpl implements BucketService {
     } catch (S3Exception ex) {
       if (ex.statusCode() == HttpStatus.UNAUTHORIZED.value()) {
         final var errMsg = String.format(ERR_MSG_UNAUTHORIZED, bucketName);
-        throw new RuntimeException(errMsg);
+        throw new S3UnauthorizedException(errMsg);
       }
       throw ex;
     }
@@ -54,7 +56,7 @@ public class BucketServiceImpl implements BucketService {
         log.info(String.format(MSG_BUCKET_CREATED, bucketName));
       } catch (Exception ex) {
         final var errMsg = String.format(ERR_MSG_BUCKET_CREATION, bucketName, ex.getMessage());
-        throw new RuntimeException(errMsg);
+        throw new S3BucketCreationException(errMsg);
       }
     }
   }

--- a/src/main/java/com/marcofaccani/awss3/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/marcofaccani/awss3/service/FileStorageServiceImpl.java
@@ -4,6 +4,11 @@ import java.time.Duration;
 import java.util.List;
 
 import com.marcofaccani.awss3.config.AwsS3ConfigProperties;
+import com.marcofaccani.awss3.exceptions.S3GetObjectException;
+import com.marcofaccani.awss3.exceptions.S3ListObjectsException;
+import com.marcofaccani.awss3.exceptions.S3PresignedUrlException;
+import com.marcofaccani.awss3.exceptions.S3ObjectDeleteException;
+import com.marcofaccani.awss3.exceptions.S3PutObjectException;
 import com.marcofaccani.awss3.service.interfaces.BucketService;
 import com.marcofaccani.awss3.service.interfaces.FileStorageService;
 import jakarta.annotation.PostConstruct;
@@ -65,7 +70,7 @@ public class FileStorageServiceImpl implements FileStorageService {
     } catch (Exception ex) {
       final var errMsg = String.format(ERR_MSG_LIST_BUCKET_CONTENT_FAILED, awsS3ConfigProperties.getBucketName(),
           ex.getMessage());
-      throw new RuntimeException(errMsg);
+      throw new S3ListObjectsException(errMsg);
     }
   }
 
@@ -79,7 +84,7 @@ public class FileStorageServiceImpl implements FileStorageService {
     try {
       s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
     } catch (Exception ex) {
-      throw new RuntimeException(String.format(ERR_MSG_UPLOAD_FAILED, file.getOriginalFilename(), ex.getMessage()));
+      throw new S3PutObjectException(String.format(ERR_MSG_UPLOAD_FAILED, file.getOriginalFilename(), ex.getMessage()));
     }
   }
 
@@ -93,7 +98,7 @@ public class FileStorageServiceImpl implements FileStorageService {
     try {
       s3Client.deleteObject(request);
     } catch (Exception ex) {
-      throw new RuntimeException(String.format(ERR_MSG_DELETE_FAILED, fileName, ex.getMessage()));
+      throw new S3ObjectDeleteException(String.format(ERR_MSG_DELETE_FAILED, fileName, ex.getMessage()));
     }
   }
 
@@ -109,7 +114,7 @@ public class FileStorageServiceImpl implements FileStorageService {
     } catch (NoSuchKeyException ex) {
       throw ex;
     } catch (Exception ex) {
-      throw new RuntimeException(String.format(ERR_MSG_RETRIEVE_FAILED, fileName, ex.getMessage()));
+      throw new S3GetObjectException(String.format(ERR_MSG_RETRIEVE_FAILED, fileName, ex.getMessage()));
     }
   }
 
@@ -129,7 +134,7 @@ public class FileStorageServiceImpl implements FileStorageService {
       return presignedGetObjectResponse.url().toString();
     } catch (Exception ex) {
       final var errMsg = String.format(ERR_MSG_GENERATE_PRESIGNEDURL_FAILED, fileName, ex.getMessage());
-      throw new RuntimeException(errMsg);
+      throw new S3PresignedUrlException(errMsg);
     }
   }
 

--- a/src/test/java/com/marcofaccani/awss3/unit/service/BucketServiceImplTest.java
+++ b/src/test/java/com/marcofaccani/awss3/unit/service/BucketServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.marcofaccani.awss3.unit.service;
 
+import com.marcofaccani.awss3.exceptions.S3BucketCreationException;
+import com.marcofaccani.awss3.exceptions.S3UnauthorizedException;
 import com.marcofaccani.awss3.service.BucketServiceImpl;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -91,7 +93,7 @@ class BucketServiceImplTest {
 
       when(s3Client.headBucket(expectedHeadBucketRequest)).thenThrow(unauthorizedException);
 
-      final var ex = assertThrows(RuntimeException.class, () -> underTest.doesBucketExist(BUCKET_NAME));
+      final var ex = assertThrows(S3UnauthorizedException.class, () -> underTest.doesBucketExist(BUCKET_NAME));
       final var expectedErrMsg = String.format(BucketServiceImpl.ERR_MSG_UNAUTHORIZED, BUCKET_NAME);
       ;
       assertEquals(expectedErrMsg, ex.getMessage());
@@ -110,7 +112,7 @@ class BucketServiceImplTest {
 
       when(s3Client.headBucket(expectedRequest)).thenThrow(badRequestException);
 
-      final var ex = assertThrows(RuntimeException.class, () -> underTest.doesBucketExist(BUCKET_NAME));
+      final var ex = assertThrows(S3Exception.class, () -> underTest.doesBucketExist(BUCKET_NAME));
       assertEquals(errMsg, ex.getMessage());
       verify(s3Client).headBucket(expectedRequest);
     }
@@ -152,7 +154,7 @@ class BucketServiceImplTest {
       final var s3ErrMsg = "s3 error message";
       when(s3Client.createBucket(expectedS3Request)).thenThrow(new RuntimeException(s3ErrMsg));
 
-      final var ex = assertThrows(RuntimeException.class, () -> underTest.createBucket(BUCKET_NAME));
+      final var ex = assertThrows(S3BucketCreationException.class, () -> underTest.createBucket(BUCKET_NAME));
       final var expectedErrMsg = String.format(BucketServiceImpl.ERR_MSG_BUCKET_CREATION, BUCKET_NAME, s3ErrMsg);
       assertEquals(expectedErrMsg, ex.getMessage());
     }


### PR DESCRIPTION
Add more specific exceptions as proposed in issue #1  
One consideration about exceptions, extending for all this specific exceptions the runtime exception it seems like less invasive to me, so you do not have to declare it on method signatures and also it is in line with what the aws sdk library does